### PR TITLE
Bug fix: stampa, terminale, doppio log...

### DIFF
--- a/sh/new_terminal.sh
+++ b/sh/new_terminal.sh
@@ -4,5 +4,5 @@ TERM_LAUNCH=gnome-terminal;
 if (($BASH_ARGC>0));
 then TERM_LAUNCH=${BASH_ARGV[0]};
 fi
-$TERM_LAUNCH -- bash -c "./bin/hmi-output"
+$TERM_LAUNCH -e ./bin/hmi-output
 

--- a/src/actuators/brake-by-wire.c
+++ b/src/actuators/brake-by-wire.c
@@ -9,9 +9,9 @@
 
 // MACROS
 // INPUT_MAX_LEN: lunghezza della stringa di input dalla central-ECU: "FRENO 5\n"
-#define INPUT_MAX_LEN 9
+#define INPUT_MAX_LEN 10
 // LOG_PHRASE_LEN: lunghezza della stringa di log: "DD/MM/YYYY hh:mm:ss - FRENO 5\n"
-#define LOG_PHRASE_LEN 30
+#define LOG_PHRASE_LEN 31
 
 // File descriptor del log file
 int log_fd;
@@ -47,7 +47,7 @@ int main ( ) {
 
 	/* Inizializzazione della stringa di input che rappresenqta il comando
 	 * impartito dalla central-ECU tramite una stringa di caratteri. */
-	char increment[INPUT_MAX_LEN];
+	char decrement[INPUT_MAX_LEN];
 	int nread;
 
   /* Il ciclo infinito successivo rappresenta il cuore del processo.
@@ -59,12 +59,12 @@ int main ( ) {
    * Quest'ultimo caso da' inizio alla procedura simulativa dell'freno.
    * Il pipe e` bloccante quindi il processo attende un messaggio dalla central-ECU */
 	while(true){
-		nread = read (pipe_fd, increment, INPUT_MAX_LEN);
+		nread = read (pipe_fd, decrement, INPUT_MAX_LEN);
 		if(nread < 0){
 			perror("brake: read");
 		}
 		if(nread > 0){
-			time_log_func( log_fd,  LOG_PHRASE_LEN, BRAKE);
+			time_log_func( log_fd, LOG_PHRASE_LEN, BRAKE);
 		}
 	}
 }

--- a/src/actuators/steer-by-wire.c
+++ b/src/actuators/steer-by-wire.c
@@ -32,13 +32,13 @@ int main(){
 	 * venga aperto in sola lettura dal processo steer-by-wire il quale vi legga al bisogno. */
 	int pipe_fd;
 	if((pipe_fd = openat (AT_FDCWD, "tmp/steer.pipe", O_RDONLY | O_NONBLOCK)) < 0){
-		perror("openat steer pipe");
+		perror("steer: openat pipe");
 		exit(EXIT_FAILURE);
 	}
 
 	// Creazione e apertura del log file e associazione del file descriptor
 	if((log_fd = openat (AT_FDCWD, "log/steer.log", O_WRONLY | O_TRUNC | O_CREAT, 0644)) < 0){
-		perror("openat steer log");
+		perror("steer: openat log");
 		exit(EXIT_FAILURE);
 	}
 
@@ -61,10 +61,7 @@ int main(){
 	 * Gli input ricevuti nel mezzo di questi intervalli saranno ignorati. */
 	while(true){
 		nread = read(pipe_fd, action, sizeof(action));
-		if(nread != -1)
-			printf("%d\n", nread);
 		switch(nread){
-
 			case 7:
 				turn(log_phrase, RIGHT);
 				perror("steer: red right");

--- a/src/actuators/throttle-control.c
+++ b/src/actuators/throttle-control.c
@@ -14,7 +14,7 @@
 #define INPUT_MAX_LEN 14
 // LOG_PHRASE_LEN: lunghezza della stringa di log:
 // "DD/MM/YYYY hh:mm:ss - AUMENTO 5\n"
-#define LOG_PHRASE_LEN 32
+#define LOG_PHRASE_LEN 33
 
 // File descriptor del log file
 int log_fd;

--- a/src/sensors/park-assist.c
+++ b/src/sensors/park-assist.c
@@ -24,15 +24,17 @@ bool restart_flag;
 
 int main(int argc, char *argv[]){
 
+	if (argc != 2){
+		perror("park-assist: syntax error");
+		exit(EXIT_FAILURE);
+	}
+
 	start_flag = false;
 	pid_t cameras_pid;
 	int log_fd,
 		cameras_fd,
 		assist_fd,
 		counter = 0;
-
-	signal(SIGUSR1,signal_start_handler);
-	signal(SIGUSR2, restart_handler);
 
 	//Apertura del log file
 	log_fd = log_open();
@@ -55,6 +57,9 @@ int main(int argc, char *argv[]){
 
 		//Connessione alla ECU
 	assist_fd = pipe_open();
+
+	signal(SIGUSR1,signal_start_handler);
+	signal(SIGUSR2, restart_handler);
 
 	while(!start_flag)
 		sleep(1);

--- a/src/sensors/windshield-camera.c
+++ b/src/sensors/windshield-camera.c
@@ -12,8 +12,8 @@
 
 // MACROS
 // INPUT_MAX_LEN: lunghezza massima della stringa proveniente dal file di
-// input: "PARCHEGGIO\0"
-#define INPUT_MAX_LEN 11
+// input: "PARCHEGGIO\n"
+#define INPUT_MAX_LEN 12
 
 void start_handler ( int );
 
@@ -21,27 +21,21 @@ void start_handler ( int );
 int log_fd;
 // File descriptor del pipe in scrittura
 int pipe_fd;
-
 int input_fd;
-
 bool start_flag = false;
 
 //La funzione main esegue le operazioni relative al componente windshield-camera
 int main ( ) {
-  errno = 0;
   signal(SIGUSR1, start_handler);
-  perror("windshield: signal eseguita");
   // Connessione del file descriptor del pipe per la comunicazione tra central
   // ECU e windshield-camera. Il protocollo impone che il pipe sia creato
   // durante la fase di inizializzazione del processo central-ECU e che venga
   // aperto in sola scrittura dal processo windshield-camera il quale vi scriva
   // una volta al secondo.
-  errno = 0;
   while((pipe_fd = openat(AT_FDCWD, "tmp/camera.pipe", O_WRONLY)) < 0){
     perror("windshield: openat pipe");
     sleep(1);
   }
-  perror("windshield: CONNECTED");
   // Connessione del file descriptor del log file. Apertura in sola scrittura.
   // Qualora il file non esista viene creato. Qualora il file sia presente
   // si mantengono le precedenti scritture. Data l'esecuzione dell'unlink
@@ -60,14 +54,13 @@ int main ( ) {
 
   // Inizializzazione della stringa di input che rappresenta il messaggio da
   // trasmettere alla central-ECU da parte del processo.
-  char *camera_input = malloc(INPUT_MAX_LEN);
+  char *camera_input = calloc(1, INPUT_MAX_LEN);
   if(camera_input == NULL){
     perror("windshield: malloc");
     exit(EXIT_FAILURE);
   }
 
   while(!start_flag){
-    perror("windshield: start_flag is false");
     sleep(1);
   }
 
@@ -92,6 +85,4 @@ int main ( ) {
 
 void start_handler(int sig){
   start_flag = true;
-  errno = 0;
-  perror("windshield: handler: start_flag is true");
 }

--- a/src/service-functions.c
+++ b/src/service-functions.c
@@ -21,10 +21,10 @@
 int initialize_pipe(char * pipe_pathname, int flags, mode_t mode){
 	unlink(pipe_pathname);
 	if(mkfifoat(AT_FDCWD, pipe_pathname, mode) < 0)
-		perror("service: mkfifoat pipe");
+		perror("init_pipe: mkfifoat pipe");
 	int pipe_fd;
 	while((pipe_fd = openat(AT_FDCWD, pipe_pathname, flags)) < 0){
-		perror("service: openat pipe");
+		perror("init_pipe: openat pipe");
 		sleep(1);
 	}
 	printf("Pipe %s inizialized\n", pipe_pathname);
@@ -138,7 +138,7 @@ pid_t make_process(char *program_name, int name_length, pid_t pgid, char *args) 
 	if(program_path == NULL)
 		perror("make process: malloc");
 	strcpy(program_path,"./bin/");
-	program_path = strcat(program_path, program_name);
+	strcat(program_path, program_name);
 	pid = fork();
 	if(pid < 0)
 		perror("make process: fork");


### PR DESCRIPTION
Modificata la ECU perche la stampa risultasse corretta (errori di lunchezza delle stringhe e formattazione), modificate le dimensioni di IN degli attuatori (doppio lettura e quindi doppio log), modificato lo script perche' possano essere eseguiti anche altre tipologie di teminali.